### PR TITLE
Fix sidebar Graph controls layout and indexing toggle sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "graph-editor"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-editor"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Kenta KOMOTO"]
 edition = "2021"
 include = ["LICENSE-APACHE", "LICENSE-MIT", "**/*.rs", "Cargo.toml"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -230,6 +230,21 @@ impl GraphEditorApp {
         self.sync_json_text_from_graph();
     }
 
+    pub fn set_zero_indexed(&mut self, zero_indexed: bool) {
+        if self.state.zero_indexed == zero_indexed {
+            return;
+        }
+
+        self.state.zero_indexed = zero_indexed;
+
+        if !self.ui.input_has_focus && !self.ui.input_is_dirty {
+            self.sync_input_text_from_graph();
+        }
+        if !self.ui.input_has_focus && !self.ui.json_is_dirty {
+            self.sync_json_text_from_graph();
+        }
+    }
+
     fn restore_imported_graph(&mut self, imported: ImportedGraph) {
         self.state.graph = imported.graph;
         self.state.graph_view = imported.view;

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,7 @@ use crate::graph::{simulation_methods, BaseGraph, Simulator};
 use crate::math::affine::Affine2D;
 use crate::mode::EditMode;
 use crate::project_io::{export_graph_to_file, import_graph_from_file, ImportedGraph, SaveOptions};
-use crate::state::{AppState, IoFormat, UiState};
+use crate::state::{AppState, IoFormat, UiState, VertexLabelMode};
 use crate::update::request_repaint;
 use crate::view_state::GraphViewState;
 
@@ -33,7 +33,8 @@ const EDGE_LENGTH_SHRINK_DIAMETER_THRESHOLD: usize = 10;
 struct StoredUiState {
     version: u32,
     zero_indexed: bool,
-    show_number: bool,
+    label_mode: Option<String>,
+    show_number: Option<bool>,
     is_animated: bool,
     is_directed: bool,
     export_format: String,
@@ -55,7 +56,8 @@ impl Default for StoredUiState {
         Self {
             version: 3,
             zero_indexed: false,
-            show_number: true,
+            label_mode: Some(VertexLabelMode::Id.storage_key().to_string()),
+            show_number: Some(true),
             is_animated: true,
             is_directed: false,
             export_format: ExportFormat::Png.extension().to_string(),
@@ -86,7 +88,17 @@ impl GraphEditorApp {
             .and_then(|storage| eframe::get_value(storage, UI_STATE_STORAGE_KEY))
             .unwrap_or_default();
         app.state.zero_indexed = state.zero_indexed;
-        app.state.show_number = state.show_number;
+        app.state.vertex_label_mode = state
+            .label_mode
+            .as_deref()
+            .map(VertexLabelMode::from_storage_key)
+            .unwrap_or_else(|| {
+                if state.show_number.unwrap_or(true) {
+                    VertexLabelMode::Id
+                } else {
+                    VertexLabelMode::Hidden
+                }
+            });
         app.state.is_animated = state.is_animated;
         app.state.graph.is_directed = state.is_directed;
         app.config.ui_font_size = state.ui_font_size;
@@ -171,7 +183,7 @@ impl GraphEditorApp {
             graph: &self.state.graph,
             view: &self.state.graph_view,
             config: &self.config,
-            show_number: self.state.show_number,
+            label_mode: self.state.vertex_label_mode,
             zero_indexed: self.state.zero_indexed,
         };
         if let Some(err) = self.export.request_export(ctx, &export_ctx) {
@@ -184,7 +196,7 @@ impl GraphEditorApp {
             graph: &self.state.graph,
             view: &self.state.graph_view,
             config: &self.config,
-            show_number: self.state.show_number,
+            label_mode: self.state.vertex_label_mode,
             zero_indexed: self.state.zero_indexed,
         };
         if let Some(err) = self.export.handle_events(ctx, &export_ctx) {
@@ -243,6 +255,10 @@ impl GraphEditorApp {
         if !self.ui.input_has_focus && !self.ui.json_is_dirty {
             self.sync_json_text_from_graph();
         }
+    }
+
+    pub fn set_vertex_label_mode(&mut self, mode: VertexLabelMode) {
+        self.state.vertex_label_mode = mode;
     }
 
     fn restore_imported_graph(&mut self, imported: ImportedGraph) {
@@ -429,7 +445,7 @@ impl Default for GraphEditorApp {
                 edit_mode: EditMode::default_normal(),
                 selected_color: Colors::Default,
                 zero_indexed: false,
-                show_number: true,
+                vertex_label_mode: VertexLabelMode::Id,
             },
             ui: UiState {
                 cursor_hover: CursorHoverState::default(),
@@ -463,7 +479,8 @@ impl eframe::App for GraphEditorApp {
         let state = StoredUiState {
             version: 3,
             zero_indexed: self.state.zero_indexed,
-            show_number: self.state.show_number,
+            label_mode: Some(self.state.vertex_label_mode.storage_key().to_string()),
+            show_number: None,
             is_animated: self.state.is_animated,
             is_directed: self.state.graph.is_directed,
             export_format: self.export.format().extension().to_string(),

--- a/src/components/central_panel.rs
+++ b/src/components/central_panel.rs
@@ -103,7 +103,7 @@ fn change_edit_mode(app: &mut GraphEditorApp, ui: &egui::Ui) {
         }
     }
     if ui.input(|i| i.key_pressed(egui::Key::Num1)) {
-        app.state.zero_indexed ^= true;
+        app.set_zero_indexed(!app.state.zero_indexed);
     }
 }
 

--- a/src/components/central_panel.rs
+++ b/src/components/central_panel.rs
@@ -614,19 +614,26 @@ fn render_vertices(
             vertex_radius,
             egui::Stroke::new(vertex_stroke, app.config.vertex_color_outline),
         );
-        if app.state.show_number {
-            let vertex_show_id = vertex.label.clone().unwrap_or_else(|| {
+        let vertex_text = match app.state.vertex_label_mode {
+            crate::state::VertexLabelMode::Id => Some(
                 if app.state.zero_indexed {
                     vertex.id
                 } else {
                     vertex.id + 1
                 }
-                .to_string()
-            });
+                .to_string(),
+            ),
+            crate::state::VertexLabelMode::Label => vertex
+                .label
+                .clone()
+                .filter(|label| !label.trim().is_empty()),
+            crate::state::VertexLabelMode::Hidden => None,
+        };
+        if let Some(vertex_text) = vertex_text {
             painter.text(
                 vertex.position,
                 egui::Align2::CENTER_CENTER,
-                vertex_show_id,
+                vertex_text,
                 egui::FontId::proportional(vertex_font_size),
                 vertex
                     .text_color

--- a/src/components/footer.rs
+++ b/src/components/footer.rs
@@ -72,14 +72,14 @@ pub fn draw_footer(app: &mut GraphEditorApp, ctx: &Context) {
                 if animate.clicked() {
                     app.set_animation_enabled(!app.state.is_animated);
                 }
-                let show_numbers = ui
-                    .selectable_label(
-                        app.state.show_number,
-                        egui::RichText::new("Number").size(app.config.footer_font_size()),
+                let label_mode = ui
+                    .button(
+                        egui::RichText::new(app.state.vertex_label_mode.footer_label())
+                            .size(app.config.footer_font_size()),
                     )
-                    .on_hover_text("Toggle vertex number labels");
-                if show_numbers.clicked() {
-                    app.state.show_number = !app.state.show_number;
+                    .on_hover_text("Cycle vertex text display mode");
+                if label_mode.clicked() {
+                    app.set_vertex_label_mode(app.state.vertex_label_mode.next());
                 }
             });
         });

--- a/src/components/inspector_panel.rs
+++ b/src/components/inspector_panel.rs
@@ -1,7 +1,10 @@
 use egui::{text::LayoutJob, Color32, Context, FontId, TextFormat};
 
 use crate::{
-    graph::BaseGraph, project_io::import_graph_from_json, state::IoFormat, GraphEditorApp,
+    graph::BaseGraph,
+    project_io::import_graph_from_json,
+    state::IoFormat,
+    GraphEditorApp,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -116,13 +119,6 @@ pub fn draw_graph_section(app: &mut GraphEditorApp, ctx: &Context, ui: &mut egui
         .clicked()
     {
         app.state.graph_view.remove_color();
-    }
-
-    if ui
-        .button(egui::RichText::new("Remove Label").size(app.config.button_font_size()))
-        .clicked()
-    {
-        app.state.graph_view.remove_label();
     }
 
     ui.separator();

--- a/src/components/inspector_panel.rs
+++ b/src/components/inspector_panel.rs
@@ -21,32 +21,24 @@ pub fn draw_inspector_panel(app: &mut GraphEditorApp, ctx: &Context) {
                 .cursor_hover
                 .set_inspector_panel(ui.rect_contains_pointer(ui.max_rect()));
 
-            ui.columns(2, |columns| {
-                draw_tab_button(
-                    &mut columns[0],
-                    app.ui.inspector_tab == InspectorTab::Graph,
-                    "Graph",
-                    app.config.tab_font_size(),
-                    || app.ui.inspector_tab = InspectorTab::Graph,
-                );
-                draw_tab_button(
-                    &mut columns[1],
-                    app.ui.inspector_tab == InspectorTab::Io,
-                    "I/O",
-                    app.config.tab_font_size(),
-                    || app.ui.inspector_tab = InspectorTab::Io,
-                );
-            });
+            ui.label(
+                egui::RichText::new("I/O")
+                    .strong()
+                    .size(app.config.section_font_size()),
+            );
             ui.separator();
-
-            match app.ui.inspector_tab {
-                InspectorTab::Graph => draw_graph_tab(app, ctx, ui),
-                InspectorTab::Io => draw_io_tab(app, ctx, ui),
-            }
+            draw_io_tab(app, ctx, ui);
         });
 }
 
-fn draw_graph_tab(app: &mut GraphEditorApp, ctx: &Context, ui: &mut egui::Ui) {
+pub fn draw_graph_section(app: &mut GraphEditorApp, ctx: &Context, ui: &mut egui::Ui) {
+    ui.label(
+        egui::RichText::new("Graph")
+            .strong()
+            .size(app.config.section_font_size()),
+    );
+
+    ui.separator();
     ui.label(
         egui::RichText::new("Indexing")
             .strong()
@@ -57,14 +49,14 @@ fn draw_graph_tab(app: &mut GraphEditorApp, ctx: &Context, ui: &mut egui::Ui) {
         app.state.zero_indexed,
         "0-indexed",
         app.config.button_font_size(),
-        || app.state.zero_indexed = true,
+        || app.set_zero_indexed(true),
     );
     draw_toggle_button(
         ui,
         !app.state.zero_indexed,
         "1-indexed",
         app.config.button_font_size(),
-        || app.state.zero_indexed = false,
+        || app.set_zero_indexed(false),
     );
 
     ui.separator();
@@ -360,25 +352,7 @@ fn draw_toggle_button(
 ) {
     if ui
         .add_sized(
-            [170.0, 32.0],
-            egui::SelectableLabel::new(selected, egui::RichText::new(label).size(font_size)),
-        )
-        .clicked()
-    {
-        on_click();
-    }
-}
-
-fn draw_tab_button(
-    ui: &mut egui::Ui,
-    selected: bool,
-    label: &str,
-    font_size: f32,
-    on_click: impl FnOnce(),
-) {
-    if ui
-        .add_sized(
-            [ui.available_width(), 30.0],
+            [150.0, 32.0],
             egui::SelectableLabel::new(selected, egui::RichText::new(label).size(font_size)),
         )
         .clicked()

--- a/src/components/inspector_panel.rs
+++ b/src/components/inspector_panel.rs
@@ -1,10 +1,7 @@
 use egui::{text::LayoutJob, Color32, Context, FontId, TextFormat};
 
 use crate::{
-    graph::BaseGraph,
-    project_io::import_graph_from_json,
-    state::IoFormat,
-    GraphEditorApp,
+    graph::BaseGraph, project_io::import_graph_from_json, state::IoFormat, GraphEditorApp,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -10,7 +10,7 @@ mod transition_and_scale;
 pub use central_panel::draw_central_panel;
 pub use color_panel::{default_vertex_text_color, Colors};
 pub use footer::draw_footer;
-pub use inspector_panel::{draw_inspector_panel, InspectorTab};
+pub use inspector_panel::{draw_graph_section, draw_inspector_panel, InspectorTab};
 pub use modal::{draw_clear_all_modal, draw_entity_editor, draw_error_modal};
 pub use tool_bar::draw_tool_bar;
 pub use top_panel::{draw_top_panel, CursorHoverState};

--- a/src/components/modal.rs
+++ b/src/components/modal.rs
@@ -172,8 +172,12 @@ fn draw_vertex_editor(app: &mut GraphEditorApp, ui: &mut egui::Ui, index: usize)
     } else {
         (vertex.id + 1).to_string()
     };
-    let label = view.label.get_or_insert(default_label);
-    ui.text_edit_singleline(label);
+    let mut label = view.label.clone().unwrap_or_default();
+    let response =
+        ui.add(egui::TextEdit::singleline(&mut label).hint_text(format!("e.g. {default_label}")));
+    if response.changed() {
+        view.label = Some(label);
+    }
 
     ui.separator();
     ui.label(

--- a/src/components/tool_bar.rs
+++ b/src/components/tool_bar.rs
@@ -1,6 +1,10 @@
 use egui::Context;
 
-use crate::{components::Colors, mode::EditMode, GraphEditorApp};
+use crate::{
+    components::{draw_graph_section, Colors},
+    mode::EditMode,
+    GraphEditorApp,
+};
 
 pub fn draw_tool_bar(app: &mut GraphEditorApp, ctx: &Context) {
     egui::SidePanel::left("tool_bar")
@@ -96,6 +100,9 @@ pub fn draw_tool_bar(app: &mut GraphEditorApp, ctx: &Context) {
             if app.state.selected_color != prev_color {
                 app.state.edit_mode = EditMode::default_colorize();
             }
+
+            ui.separator();
+            draw_graph_section(app, ctx, ui);
         });
 }
 

--- a/src/export/codec.rs
+++ b/src/export/codec.rs
@@ -8,6 +8,7 @@ use crate::components::default_vertex_text_color;
 use crate::config::AppConfig;
 use crate::graph::Graph;
 use crate::math::bezier::{calc_bezier_control_point, calc_intersection_of_bezier_and_circle};
+use crate::state::VertexLabelMode;
 use crate::view_state::GraphViewState;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -36,7 +37,7 @@ pub struct ExportContext<'a> {
     pub graph: &'a Graph,
     pub view: &'a GraphViewState,
     pub config: &'a AppConfig,
-    pub show_number: bool,
+    pub label_mode: VertexLabelMode,
     pub zero_indexed: bool,
 }
 
@@ -372,15 +373,22 @@ pub fn export_svg_bytes(ctx: &ExportContext<'_>) -> anyhow::Result<Vec<u8>> {
             ));
         }
 
-        if ctx.show_number {
-            let vertex_show_id = vertex.label.clone().unwrap_or_else(|| {
+        let vertex_text = match ctx.label_mode {
+            VertexLabelMode::Id => Some(
                 if ctx.zero_indexed {
                     vertex.id
                 } else {
                     vertex.id + 1
                 }
-                .to_string()
-            });
+                .to_string(),
+            ),
+            VertexLabelMode::Label => vertex
+                .label
+                .clone()
+                .filter(|label| !label.trim().is_empty()),
+            VertexLabelMode::Hidden => None,
+        };
+        if let Some(vertex_text) = vertex_text {
             let (text_hex, text_alpha) = color_to_svg(
                 vertex
                     .text_color
@@ -389,11 +397,11 @@ pub fn export_svg_bytes(ctx: &ExportContext<'_>) -> anyhow::Result<Vec<u8>> {
             let text_adjust_y = y + 4.5;
             if let Some(alpha) = text_alpha {
                 svg.push_str(&format!(
-                    "  <text x=\"{x}\" y=\"{text_adjust_y}\" text-anchor=\"middle\" dominant-baseline=\"middle\" font-size=\"{vertex_font_size}\" fill=\"{text_hex}\" fill-opacity=\"{alpha}\">{vertex_show_id}</text>\n",
+                    "  <text x=\"{x}\" y=\"{text_adjust_y}\" text-anchor=\"middle\" dominant-baseline=\"middle\" font-size=\"{vertex_font_size}\" fill=\"{text_hex}\" fill-opacity=\"{alpha}\">{vertex_text}</text>\n",
                 ));
             } else {
                 svg.push_str(&format!(
-                    "  <text x=\"{x}\" y=\"{text_adjust_y}\" text-anchor=\"middle\" dominant-baseline=\"middle\" font-size=\"{vertex_font_size}\" fill=\"{text_hex}\">{vertex_show_id}</text>\n",
+                    "  <text x=\"{x}\" y=\"{text_adjust_y}\" text-anchor=\"middle\" dominant-baseline=\"middle\" font-size=\"{vertex_font_size}\" fill=\"{text_hex}\">{vertex_text}</text>\n",
                 ));
             }
         }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -12,6 +12,56 @@ pub enum IoFormat {
     Json,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum VertexLabelMode {
+    #[default]
+    Id,
+    Label,
+    Hidden,
+}
+
+impl VertexLabelMode {
+    pub fn storage_key(self) -> &'static str {
+        match self {
+            Self::Id => "id",
+            Self::Label => "label",
+            Self::Hidden => "hidden",
+        }
+    }
+
+    pub fn from_storage_key(value: &str) -> Self {
+        match value {
+            "label" => Self::Label,
+            "hidden" => Self::Hidden,
+            _ => Self::Id,
+        }
+    }
+
+    pub fn button_label(self) -> &'static str {
+        match self {
+            Self::Id => "Vertex ID",
+            Self::Label => "Label",
+            Self::Hidden => "Hidden",
+        }
+    }
+
+    pub fn footer_label(self) -> &'static str {
+        match self {
+            Self::Id => "Text: ID",
+            Self::Label => "Text: Label",
+            Self::Hidden => "Text: Hidden",
+        }
+    }
+
+    pub fn next(self) -> Self {
+        match self {
+            Self::Id => Self::Label,
+            Self::Label => Self::Hidden,
+            Self::Hidden => Self::Id,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EditTarget {
     Vertex(usize),
@@ -28,7 +78,7 @@ pub struct AppState {
     pub edit_mode: EditMode,
     pub selected_color: Colors,
     pub zero_indexed: bool,
-    pub show_number: bool,
+    pub vertex_label_mode: VertexLabelMode,
 }
 
 pub struct UiState {

--- a/src/view_state.rs
+++ b/src/view_state.rs
@@ -25,7 +25,7 @@ impl Default for VertexViewState {
             z_index: 0,
             drag: Affine2D::one(),
             color: Colors::default(),
-            label: None,
+            label: Some(String::new()),
             text_color: None,
             radius: None,
             stroke_width: None,
@@ -121,12 +121,6 @@ impl GraphViewState {
         }
         for edge in &mut self.edges {
             edge.color = Colors::default();
-        }
-    }
-
-    pub fn remove_label(&mut self) {
-        for vertex in &mut self.vertices {
-            vertex.label = Some(String::default());
         }
     }
 


### PR DESCRIPTION
## Summary
- move the `Graph` controls from the right inspector into the open space in the left sidebar
- keep the right sidebar focused on `I/O`
- align the width of the indexing toggle buttons with the mode buttons
- fix `0-indexed` / `1-indexed` toggles so they update synced text state consistently

## Testing
- `cargo fmt`
- `cargo check`